### PR TITLE
Target will set name to the locator string by default

### DIFF
--- a/docs/targets.rst
+++ b/docs/targets.rst
@@ -53,3 +53,33 @@ by passing them to Actions::
         Enter.the_secret("reallySecurePassword!!").into_the(PASSWORD_FIELD),
         Click.on_the(SIGN_IN_BUTTON),
     )
+
+The resulting log::
+
+    Webster enters "webster_1987" into the username field.
+    Webster enters "[CENSORED]" into the password field.
+    Websert clicks on the "Sign In" button.
+
+By default the :ref:`target` will use the locator string as a human-readable
+target name in the absense of providing one. This can be convenient if your
+locators are self-describing::
+
+    from screenpy_selenium import Target
+    from selenium.webdriver.common.by import By
+    
+    USERNAME_FIELD = Target().located((By.ID, "username-field"))
+    PASSWORD_FIELD = Target().located((By.ID, "password-field"))
+    SIGN_IN_BUTTON = Target().located((By.ID, "sign-in-button"))
+    
+    Webster.attempts_to(
+        Enter.the_text("foo").into_the(USERNAME_FIELD),
+        Enter.the_secret("bar").into_the(PASSWORD_FIELD),
+        Click.on_the(SIGN_IN_BUTTON),
+    )
+
+The resulting log::
+
+    Webster enters "foo" into the username-field.
+    Webster enters "[CENSORED]" into the password-field.
+    Websert clicks on the sign-in-button.
+

--- a/docs/targets.rst
+++ b/docs/targets.rst
@@ -54,14 +54,14 @@ by passing them to Actions::
         Click.on_the(SIGN_IN_BUTTON),
     )
 
-The resulting log::
+The resulting log:
 
-    Webster enters "webster_1987" into the username field.
-    Webster enters "[CENSORED]" into the password field.
-    Websert clicks on the "Sign In" button.
+    | Webster enters "webster_1987" into the username field.
+    | Webster enters "[CENSORED]" into the password field.
+    | Websert clicks on the "Sign In" button.
 
 By default the :ref:`target` will use the locator string as a human-readable
-target name in the absense of providing one. This can be convenient if your
+``target_name`` in the absence of providing one. This can be convenient if your
 locators are self-describing::
 
     from screenpy_selenium import Target
@@ -77,9 +77,9 @@ locators are self-describing::
         Click.on_the(SIGN_IN_BUTTON),
     )
 
-The resulting log::
+The resulting log:
 
-    Webster enters "foo" into the username-field.
-    Webster enters "[CENSORED]" into the password-field.
-    Websert clicks on the sign-in-button.
+    | Webster enters "foo" into the username-field.
+    | Webster enters "[CENSORED]" into the password-field.
+    | Websert clicks on the sign-in-button.
 

--- a/screenpy_selenium/target.py
+++ b/screenpy_selenium/target.py
@@ -37,9 +37,7 @@ class Target:
     def target_name(self):
         if self._description is not None:
             return self._description
-        if self.locator:
-            return self.locator[1]
-        return self._description
+        return self.locator[1] if self.locator else None
 
     @target_name.setter
     def target_name(self, value):

--- a/screenpy_selenium/target.py
+++ b/screenpy_selenium/target.py
@@ -116,7 +116,7 @@ class Target:
             raise TargetingError(f"{e} raised while trying to find {self}.") from e
 
     def __repr__(self) -> str:
-        return self.target_name
+        return f"{self.target_name}"
 
     __str__ = __repr__
 

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -150,3 +150,18 @@ def test_empty_target_iterator():
     nulltarget = Target("bogus")
     with pytest.raises(TargetingError):
         iter(nulltarget)
+
+
+def test_repr():
+    t1 = Target()
+    t2 = Target("foo")
+    assert repr(t1) == "None"
+    assert repr(t2) == "foo"
+
+
+def test_str():
+    t1 = Target()
+    t2 = Target("foo")
+    assert str(t1) == "None"
+    assert str(t2) == "foo"
+    

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -10,9 +10,36 @@ from screenpy_selenium.exceptions import TargetingError
 def test_can_be_instantiated():
     t1 = Target.the("test")
     t2 = Target.the("test").located_by("test")
+    t3 = Target.the("test").located("test")
+    t4 = Target("test")
+    t5 = Target().located_by("test")
+    t6 = Target()
 
     assert isinstance(t1, Target)
     assert isinstance(t2, Target)
+    assert isinstance(t3, Target)
+    assert isinstance(t4, Target)
+    assert isinstance(t5, Target)
+    assert isinstance(t6, Target)
+
+
+def test_auto_describe():
+    """When no description is provided, automatically use the string of the locator"""
+    t1 = Target().located_by((By.ID, "foo-id"))
+    t2 = Target("blah").located_by("foo")
+    t3 = Target()
+    t4 = Target("").located("baz")
+
+    assert t1.target_name == "foo-id"
+    assert t2.target_name == "blah"
+    assert t3.target_name == None
+    assert t4.target_name == ""
+
+
+def test_del_description():
+    t1 = Target("test")
+    del(t1.target_name)
+    assert t1.target_name == None
 
 
 def test_complains_for_no_locator():
@@ -28,13 +55,17 @@ def test_get_locator():
     css_selector = "#id"
     xpath_locator = '//div[@id="id"]'
     xpath_locator_2 = "(//a)[5]"
+    id_locator = "someID"
+
     css_target = Target.the("css element").located_by(css_selector)
     xpath_target = Target.the("xpath element").located_by(xpath_locator)
     xpath_target_2 = Target.the("xpath element 2").located_by(xpath_locator_2)
+    id_target = Target.the("id element").located_by((By.ID, id_locator))
 
     assert css_target.get_locator() == (By.CSS_SELECTOR, css_selector)
     assert xpath_target.get_locator() == (By.XPATH, xpath_locator)
     assert xpath_target_2.get_locator() == (By.XPATH, xpath_locator_2)
+    assert id_target.get_locator() == (By.ID, id_locator)
 
 
 def test_located():
@@ -51,6 +82,20 @@ def test_can_be_indexed():
 
     assert target[0] == locator[0]
     assert target[1] == locator[1]
+
+
+def test_locator_tuple_size():
+    with pytest.raises(ValueError) as excinfo:
+        Target("test").located((By.ID, "foo", "baz"))
+    assert "locator tuple length should be 2" in f"{excinfo.value}"
+
+    with pytest.raises(ValueError) as excinfo:
+        Target("test").located((By.ID,))
+    assert "locator tuple length should be 2" in f"{excinfo.value}"
+
+    with pytest.raises(TypeError) as excinfo:
+        Target("test").located_by([By.ID, "foo"])
+    assert "invalid locator type" in f"{excinfo.value}"
 
 
 def test_found_by(Tester):


### PR DESCRIPTION
Adding a convenience to `Target` when the locators are self-describing, allowing for shorter object creation:
`Target().located_by((By.ID, "username-field"))`