### PR TITLE
#19: fix extra indentation in add_to_chain beats.

### DIFF
--- a/screenpy_selenium/actions/click.py
+++ b/screenpy_selenium/actions/click.py
@@ -75,7 +75,7 @@ class Click:
             )
             raise DeliveryError(msg) from e
 
-    @beat("  Click{description}!")
+    @beat("Click{description}!")
     def add_to_chain(
         self: SelfClick, the_actor: Actor, the_chain: ActionChains
     ) -> None:

--- a/screenpy_selenium/actions/double_click.py
+++ b/screenpy_selenium/actions/double_click.py
@@ -75,7 +75,7 @@ class DoubleClick:
         self._add_action_to_chain(the_actor, the_chain)
         the_chain.perform()
 
-    @beat("  Double-click{description}!")
+    @beat("Double-click{description}!")
     def add_to_chain(
         self: SelfDoubleClick, the_actor: Actor, the_chain: ActionChains
     ) -> None:

--- a/screenpy_selenium/actions/enter_2fa_token.py
+++ b/screenpy_selenium/actions/enter_2fa_token.py
@@ -51,7 +51,7 @@ class Enter2FAToken:
         token = the_actor.uses_ability_to(AuthenticateWith2FA).to_get_token()
         the_actor.attempts_to(Enter.the_text(token).into_the(self.target))
 
-    @beat("  Enter their 2FA token into the {target}!")
+    @beat("Enter their 2FA token into the {target}!")
     def add_to_chain(
         self: SelfEnter2FAToken, the_actor: Actor, the_chain: ActionChains
     ) -> None:

--- a/screenpy_selenium/actions/hold_down.py
+++ b/screenpy_selenium/actions/hold_down.py
@@ -69,7 +69,7 @@ class HoldDown:
         """Describe the Action in present tense."""
         return f"Hold down {self.description}."
 
-    @beat("  Hold down {description}!")
+    @beat("Hold down {description}!")
     def add_to_chain(
         self: SelfHoldDown, the_actor: Actor, the_chain: ActionChains
     ) -> None:

--- a/screenpy_selenium/actions/move_mouse.py
+++ b/screenpy_selenium/actions/move_mouse.py
@@ -125,7 +125,7 @@ class MoveMouse:
         self._add_action_to_chain(the_actor, the_chain)
         the_chain.perform()
 
-    @beat("  Move the mouse {description}!")
+    @beat("Move the mouse {description}!")
     def add_to_chain(
         self: SelfMoveMouse, the_actor: Actor, the_chain: ActionChains
     ) -> None:

--- a/screenpy_selenium/actions/pause.py
+++ b/screenpy_selenium/actions/pause.py
@@ -34,7 +34,7 @@ class Pause(BasePause):
         )
     """
 
-    @beat("  Pause for {number} {unit} ({reason})!")
+    @beat("Pause for {number} {unit} ({reason})!")
     def add_to_chain(self, _: Actor, the_chain: ActionChains) -> None:
         """Add the Pause Action to a Chain of Actions."""
         the_chain.pause(self.time)

--- a/screenpy_selenium/actions/release.py
+++ b/screenpy_selenium/actions/release.py
@@ -60,7 +60,7 @@ class Release:
         # darn, it doesn't work quite as well here. :P
         return f"Release {self.the_kraken}."
 
-    @beat("  Release {the_kraken}!")
+    @beat("Release {the_kraken}!")
     def add_to_chain(self: SelfRelease, _: Actor, the_chain: ActionChains) -> None:
         """Add the Release Action to a Chain of Actions."""
         if self.lmb:

--- a/screenpy_selenium/actions/right_click.py
+++ b/screenpy_selenium/actions/right_click.py
@@ -79,7 +79,7 @@ class RightClick:
         self._add_action_to_chain(the_actor, the_chain)
         the_chain.perform()
 
-    @beat("  Right-click{description}!")
+    @beat("Right-click{description}!")
     def add_to_chain(
         self: SelfRightClick, the_actor: Actor, the_chain: ActionChains
     ) -> None:


### PR DESCRIPTION
A long, long time ago, before ScreenPy was split up, and before we had The Narrator... the little extra indent on chained Actions helped to show which Actions were part of the chain.

ScreenPy has grown up, and out, and now we've got some more sophisticated systems in place to log things much nicer. Those extra indents are now weird anomalies! Granted, weird anomalies that aren't easy to see, but annoying to those who notice (*cough* @bandophahita *cough*).

This PR removes that extra little indentation, since it's no longer needed!