### PR TITLE
Ruff enable fbt

### DIFF
--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -1,0 +1,80 @@
+============
+Deprecations
+============
+
+This page documents
+the major deprecations
+in ScreenPy Selenium's life,
+and how to adjust your tests
+to keep them up to date.
+
+4.1.0 Deprecations
+==================
+
+Boolean Positional Arguments Deprecation
+----------------------------------------
+
+The following class constructors 
+have been marked deprecated 
+when using a positional boolean argument in the constructor. 
+Starting with version 5.0.0
+you will be required to provide keywords 
+for the following boolean arguments.
+
+:class:`~screenpy_selenium.actions.enter.Enter`
+
+Before::
+
+    the_actor.will(Enter("foo", True).into_the(PASSWORD))
+
+After::
+
+    the_actor.will(Enter("foo", mask=True).into_the(PASSWORD))
+
+
+:class:`~screenpy_selenium.actions.hold_down.HoldDown`
+
+Before::
+
+    the_actor.will(Chain(HoldDown(None, True))
+
+After::
+
+    the_actor.will(Chain(HoldDown(None, lmb=True))
+    the_actor.will(Chain(HoldDown(lmb=True))
+    
+
+:class:`~screenpy_selenium.actions.release.Release`
+
+Before::
+
+    the_actor.will(Release(None, True))
+
+After::
+
+    the_actor.will(Release(None, lmb=True))
+    the_actor.will(Release(lmb=True))
+
+
+:class:`~screenpy_selenium.questions.selected.Selected`
+
+Before::
+
+    the_actor.shall(See.the(Selected(TARGET, True), IsEmpty()))
+
+After::
+
+    the_actor.shall(See.the(Selected(TARGET, multi=True), IsEmpty()))
+
+
+:class:`~screenpy_selenium.questions.text.Text`
+
+Before::
+
+    the_actor.shall(See.the(Text(TARGET, True), IsEqual("foo"))
+
+After::
+
+    the_actor.shall(See.the(Text(TARGET, multi=True), IsEqual("foo")
+
+

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -23,22 +23,30 @@ for the following boolean arguments.
 
 :class:`~screenpy_selenium.actions.enter.Enter`
 
-Before::
+Before:
+
+.. code-block:: python
 
     the_actor.will(Enter("foo", True).into_the(PASSWORD))
 
-After::
+After:
+
+.. code-block:: python
 
     the_actor.will(Enter("foo", mask=True).into_the(PASSWORD))
 
 
 :class:`~screenpy_selenium.actions.hold_down.HoldDown`
 
-Before::
+Before:
+
+.. code-block:: python
 
     the_actor.will(Chain(HoldDown(None, True))
 
-After::
+After:
+
+.. code-block:: python
 
     the_actor.will(Chain(HoldDown(None, lmb=True))
     the_actor.will(Chain(HoldDown(lmb=True))
@@ -46,11 +54,15 @@ After::
 
 :class:`~screenpy_selenium.actions.release.Release`
 
-Before::
+Before:
+
+.. code-block:: python
 
     the_actor.will(Release(None, True))
 
-After::
+After:
+
+.. code-block:: python
 
     the_actor.will(Release(None, lmb=True))
     the_actor.will(Release(lmb=True))
@@ -58,22 +70,30 @@ After::
 
 :class:`~screenpy_selenium.questions.selected.Selected`
 
-Before::
+Before:
+
+.. code-block:: python
 
     the_actor.shall(See.the(Selected(TARGET, True), IsEmpty()))
 
-After::
+After:
+
+.. code-block:: python
 
     the_actor.shall(See.the(Selected(TARGET, multi=True), IsEmpty()))
 
 
 :class:`~screenpy_selenium.questions.text.Text`
 
-Before::
+Before:
+
+.. code-block:: python
 
     the_actor.shall(See.the(Text(TARGET, True), IsEqual("foo"))
 
-After::
+After:
+
+.. code-block:: python
 
     the_actor.shall(See.the(Text(TARGET, multi=True), IsEqual("foo")
 

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -21,6 +21,13 @@ Starting with version 5.0.0
 you will be required to provide keywords 
 for the following boolean arguments.
 
+While our documentation does not explicitly outline using these Actions in this way,
+it's still possible to do so. 
+If you are using Actions directly from their constructors 
+like the below examples, 
+here are the fixes you'll need to implement.
+
+
 :class:`~screenpy_selenium.actions.enter.Enter`
 
 Before:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,3 +28,4 @@ to :class:`~screenpy_selenium.abilities.BrowseTheWeb`!
    extended_api
    targets
    cookbook
+   deprecations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ select = [
     "ERA",  # eradicate
     "F",  # Pyflakes
     "FA",  # flake8-future-annotations
-#    "FBT",  # flake8-boolean-trap
+    "FBT",  # flake8-boolean-trap
     "FIX",  # flake8-fixme
     "FLY",  # flynt
     "I",  # isort

--- a/screenpy_selenium/actions/enter.py
+++ b/screenpy_selenium/actions/enter.py
@@ -9,6 +9,7 @@ from screenpy.exceptions import DeliveryError, UnableToAct
 from screenpy.pacing import aside, beat
 from selenium.common.exceptions import WebDriverException
 
+from ..common import pos_args_deprecated
 from ..speech_tools import KEY_NAMES
 
 if TYPE_CHECKING:
@@ -152,7 +153,10 @@ class Enter:
         for key in self.following_keys:
             send_keys(key)
 
-    def __init__(self: SelfEnter, text: str, mask: bool = False) -> None:
+    @pos_args_deprecated("mask")
+    def __init__(
+        self: SelfEnter, text: str, mask: bool = False  # noqa: FBT001, FBT002
+    ) -> None:
         self.text = text
         self.target = None
         self.following_keys = []

--- a/screenpy_selenium/actions/hold_down.py
+++ b/screenpy_selenium/actions/hold_down.py
@@ -9,6 +9,7 @@ from screenpy.exceptions import UnableToAct
 from screenpy.pacing import beat
 from selenium.webdriver.common.keys import Keys
 
+from ..common import pos_args_deprecated
 from ..speech_tools import KEY_NAMES
 
 if TYPE_CHECKING:
@@ -88,7 +89,12 @@ class HoldDown:
             msg = "HoldDown must be told what to hold down."
             raise UnableToAct(msg)
 
-    def __init__(self: SelfHoldDown, key: str | None = None, lmb: bool = False) -> None:
+    @pos_args_deprecated("lmb")
+    def __init__(
+        self: SelfHoldDown,
+        key: str | None = None,
+        lmb: bool = False,  # noqa: FBT001, FBT002
+    ) -> None:
         self.key = key
         self.lmb = lmb
         self.target = None

--- a/screenpy_selenium/actions/release.py
+++ b/screenpy_selenium/actions/release.py
@@ -9,6 +9,7 @@ from screenpy.exceptions import UnableToAct
 from screenpy.pacing import beat
 from selenium.webdriver.common.keys import Keys
 
+from ..common import pos_args_deprecated
 from ..speech_tools import KEY_NAMES
 
 if TYPE_CHECKING:
@@ -75,7 +76,12 @@ class Release:
             msg = "Release must be told what to release."
             raise UnableToAct(msg)
 
-    def __init__(self: SelfRelease, key: str | None = None, lmb: bool = False) -> None:
+    @pos_args_deprecated("lmb")
+    def __init__(
+        self: SelfRelease,
+        key: str | None = None,
+        lmb: bool = False,  # noqa: FBT001, FBT002
+    ) -> None:
         self.key = key
         self.lmb = lmb
         self.description = "LEFT MOUSE BUTTON" if lmb else KEY_NAMES[key]

--- a/screenpy_selenium/common.py
+++ b/screenpy_selenium/common.py
@@ -1,0 +1,42 @@
+"""module to hold shared objects."""
+from __future__ import annotations
+
+import warnings
+from functools import wraps
+from typing import TYPE_CHECKING, Callable, ParamSpec, TypeVar
+
+if TYPE_CHECKING:
+    P = ParamSpec("P")
+    T = TypeVar("T")
+    Function = Callable[P, T]
+
+
+def pos_args_deprecated(*keywords: str) -> Function:
+    """Warn users which positional arguments should be called via keyword."""
+
+    def deprecated(func: Function) -> Function:
+        argnames = func.__code__.co_varnames[: func.__code__.co_argcount]
+        i = min([argnames.index(kw) for kw in keywords])
+        kw_argnames = argnames[i:]
+
+        @wraps(func)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> Function:
+            # call the function first, to make sure the signature matches
+            ret_value = func(*args, **kwargs)
+
+            args_that_should_be_kw = args[i:]
+            if args_that_should_be_kw:
+                posargnames = ", ".join(kw_argnames)
+
+                msg = (
+                    f"Warning: positional arguments `{posargnames}` for "
+                    f"`{func.__qualname__}` are deprecated.  "
+                    f"Please use keyword arguments instead."
+                )
+                warnings.warn(msg, DeprecationWarning, stacklevel=2)
+
+            return ret_value
+
+        return wrapper
+
+    return deprecated

--- a/screenpy_selenium/common.py
+++ b/screenpy_selenium/common.py
@@ -1,4 +1,4 @@
-"""module to hold shared objects."""
+"""Module to hold shared objects."""
 
 from __future__ import annotations
 

--- a/screenpy_selenium/common.py
+++ b/screenpy_selenium/common.py
@@ -33,7 +33,8 @@ def pos_args_deprecated(*keywords: str) -> Function:
 
                 msg = (
                     f"Warning: positional arguments `{posargnames}` for "
-                    f"`{func.__qualname__}` are deprecated.  "
+                    f"`{func.__qualname__}` are deprecated "
+                    f"and will be removed in version 5. "
                     f"Please use keyword arguments instead."
                 )
                 warnings.warn(msg, DeprecationWarning, stacklevel=2)

--- a/screenpy_selenium/common.py
+++ b/screenpy_selenium/common.py
@@ -1,9 +1,12 @@
 """module to hold shared objects."""
+
 from __future__ import annotations
 
 import warnings
 from functools import wraps
-from typing import TYPE_CHECKING, Callable, ParamSpec, TypeVar
+from typing import TYPE_CHECKING, Callable, TypeVar
+
+from typing_extensions import ParamSpec
 
 if TYPE_CHECKING:
     P = ParamSpec("P")

--- a/screenpy_selenium/questions/selected.py
+++ b/screenpy_selenium/questions/selected.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, TypeVar
 from screenpy.pacing import beat
 from selenium.webdriver.support.ui import Select as SeleniumSelect
 
+from ..common import pos_args_deprecated
+
 if TYPE_CHECKING:
     from screenpy import Actor
 
@@ -90,6 +92,9 @@ class Selected:
             return [e.text for e in select.all_selected_options]
         return select.first_selected_option.text
 
-    def __init__(self: SelfSelected, target: Target, multi: bool = False) -> None:
+    @pos_args_deprecated("multi")
+    def __init__(
+        self: SelfSelected, target: Target, multi: bool = False  # noqa: FBT001, FBT002
+    ) -> None:
         self.target = target
         self.multi = multi

--- a/screenpy_selenium/questions/text.py
+++ b/screenpy_selenium/questions/text.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING, TypeVar
 
 from screenpy.pacing import beat
 
+from ..common import pos_args_deprecated
+
 if TYPE_CHECKING:
     from screenpy import Actor
 
@@ -70,6 +72,9 @@ class Text:
             return [e.text for e in self.target.all_found_by(the_actor)]
         return self.target.found_by(the_actor).text
 
-    def __init__(self: SelfText, target: Target, multi: bool = False) -> None:
+    @pos_args_deprecated("multi")
+    def __init__(
+        self: SelfText, target: Target, multi: bool = False  # noqa: FBT001, FBT002
+    ) -> None:
         self.target = target
         self.multi = multi

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -928,7 +928,7 @@ class TestRelease:
 
     def test_positional_arg_warns(self) -> None:
         with pytest.warns(DeprecationWarning):
-            Release(None, True)
+            Release(Keys.LEFT_ALT, True)
 
     def test_keyword_arg_does_not_warn(self) -> None:
         with not_raises(DeprecationWarning), warnings.catch_warnings():

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from typing import cast
 from unittest import mock
 
@@ -435,6 +436,19 @@ class TestEnter:
 
         assert SubEnter.the_text("blah").new_method() is True
 
+    def test_positional_arg_warns(self) -> None:
+        with pytest.warns(DeprecationWarning):
+            Enter("", True)
+
+    def test_keyword_arg_does_not_warn(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            Enter.the_secret("")
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            Enter("", mask=True)
+
 
 class TestEnter2FAToken:
     def test_can_be_instantiated(self) -> None:
@@ -618,6 +632,19 @@ class TestHoldDown:
                 return True
 
         assert SubHoldDown.left_mouse_button().new_method() is True
+
+    def test_positional_arg_warns(self) -> None:
+        with pytest.warns(DeprecationWarning):
+            HoldDown(Keys.LEFT_ALT, True)
+
+    def test_keyword_arg_does_not_warn(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            HoldDown.left_mouse_button()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            HoldDown(lmb=True)
 
 
 class TestMoveMouse:
@@ -883,6 +910,19 @@ class TestRelease:
                 return True
 
         assert SubRelease.left_mouse_button().new_method() is True
+
+    def test_positional_arg_warns(self) -> None:
+        with pytest.warns(DeprecationWarning):
+            Release(Keys.LEFT_ALT, True)
+
+    def test_keyword_arg_does_not_warn(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            Release.left_mouse_button()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            Release(lmb=True)
 
 
 class TestRespondToThePrompt:

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import warnings
-from typing import cast
+from contextlib import contextmanager
+from typing import Generator, cast
 from unittest import mock
 
 import pytest
@@ -62,6 +63,20 @@ from .useful_mocks import (
 
 FakeTarget = get_mock_target_class()
 TARGET = FakeTarget()
+
+
+@contextmanager
+def not_raises(ExpectedException: type[Exception]) -> Generator:
+    try:
+        yield
+
+    except ExpectedException as error:
+        msg = f"Incorrectly Raised {error}"
+        raise AssertionError(msg) from error
+
+    except Exception as error:  # noqa: BLE001
+        msg = f"Unexpected exception {error}"
+        raise AssertionError(msg) from error
 
 
 class TestAcceptAlert:
@@ -441,11 +456,11 @@ class TestEnter:
             Enter("", True)
 
     def test_keyword_arg_does_not_warn(self) -> None:
-        with warnings.catch_warnings():
+        with not_raises(DeprecationWarning), warnings.catch_warnings():
             warnings.simplefilter("error")
             Enter.the_secret("")
 
-        with warnings.catch_warnings():
+        with not_raises(DeprecationWarning), warnings.catch_warnings():
             warnings.simplefilter("error")
             Enter("", mask=True)
 
@@ -638,11 +653,11 @@ class TestHoldDown:
             HoldDown(None, True)
 
     def test_keyword_arg_does_not_warn(self) -> None:
-        with warnings.catch_warnings():
+        with not_raises(DeprecationWarning), warnings.catch_warnings():
             warnings.simplefilter("error")
             HoldDown.left_mouse_button()
 
-        with warnings.catch_warnings():
+        with not_raises(DeprecationWarning), warnings.catch_warnings():
             warnings.simplefilter("error")
             HoldDown(lmb=True)
 
@@ -916,11 +931,11 @@ class TestRelease:
             Release(None, True)
 
     def test_keyword_arg_does_not_warn(self) -> None:
-        with warnings.catch_warnings():
+        with not_raises(DeprecationWarning), warnings.catch_warnings():
             warnings.simplefilter("error")
             Release.left_mouse_button()
 
-        with warnings.catch_warnings():
+        with not_raises(DeprecationWarning), warnings.catch_warnings():
             warnings.simplefilter("error")
             Release(lmb=True)
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -650,7 +650,7 @@ class TestHoldDown:
 
     def test_positional_arg_warns(self) -> None:
         with pytest.warns(DeprecationWarning):
-            HoldDown(None, True)
+            HoldDown(Keys.LEFT_ALT, True)
 
     def test_keyword_arg_does_not_warn(self) -> None:
         with not_raises(DeprecationWarning), warnings.catch_warnings():

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -635,7 +635,7 @@ class TestHoldDown:
 
     def test_positional_arg_warns(self) -> None:
         with pytest.warns(DeprecationWarning):
-            HoldDown(Keys.LEFT_ALT, True)
+            HoldDown(None, True)
 
     def test_keyword_arg_does_not_warn(self) -> None:
         with warnings.catch_warnings():
@@ -913,7 +913,7 @@ class TestRelease:
 
     def test_positional_arg_warns(self) -> None:
         with pytest.warns(DeprecationWarning):
-            Release(Keys.LEFT_ALT, True)
+            Release(None, True)
 
     def test_keyword_arg_does_not_warn(self) -> None:
         with warnings.catch_warnings():

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from unittest import mock
 
 import pytest
@@ -309,6 +310,19 @@ class TestSelected:
             Selected(TARGET).describe() == f"The selected option(s) from the {TARGET}."
         )
 
+    def test_positional_arg_warns(self) -> None:
+        with pytest.warns(DeprecationWarning):
+            Selected(TARGET, True)
+
+    def test_keyword_arg_does_not_warn(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            Selected.options_from_the(TARGET)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            Selected(TARGET, multi=True)
+
 
 class TestText:
     def test_can_be_instantiated(self) -> None:
@@ -379,3 +393,16 @@ class TestTextOfTheAlert:
 
     def test_describe(self) -> None:
         assert TextOfTheAlert().describe() == "The text of the alert."
+
+    def test_positional_arg_warns(self) -> None:
+        with pytest.warns(DeprecationWarning):
+            Text(TARGET, True)
+
+    def test_keyword_arg_does_not_warn(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            Text.of_all(TARGET)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            Text(TARGET, multi=True)


### PR DESCRIPTION
The final ruff rule.  

[FBT](https://docs.astral.sh/ruff/rules/boolean-type-hint-positional-argument/) triggered on the fact that actions like `Enter` should not use bool in a positional argument.  Unfortunately changing the constructor for these actions could cause folks some issues.  This PR attempts to give users some time to adjust before we update these constructors.